### PR TITLE
Added support for launching devices on a subgroup of udids, also fixed some miscellaneous

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.aventstack</groupId>
             <artifactId>extentreports</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.reflections</groupId>

--- a/src/main/java/com/appium/ios/IOSDeviceConfiguration.java
+++ b/src/main/java/com/appium/ios/IOSDeviceConfiguration.java
@@ -14,6 +14,7 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
@@ -27,7 +28,8 @@ public class IOSDeviceConfiguration {
     Map<String, String> devices = new HashMap<>();
     public Process p;
     public Process p1;
-
+    private List<String> validDeviceIds;
+    
     public final static int IOS_UDID_LENGTH = 40;
 
     public static ConcurrentHashMap<Long, Integer> appiumServerProcess = new ConcurrentHashMap<>();
@@ -62,7 +64,12 @@ public class IOSDeviceConfiguration {
                 return null;
             } else {
                 while (endPos < getIOSDeviceID.length()) {
-                    deviceUDIDiOS.add(getIOSDeviceID.substring(startPos, endPos + 1));
+                    if (validDeviceIds == null 
+                            || (validDeviceIds != null 
+                            && validDeviceIds.contains(
+                                    getIOSDeviceID.substring(startPos, endPos + 1)))) {
+                        deviceUDIDiOS.add(getIOSDeviceID.substring(startPos, endPos + 1));
+                    }
                     startPos += IOS_UDID_LENGTH;
                     endPos += IOS_UDID_LENGTH;
                 }
@@ -84,7 +91,10 @@ public class IOSDeviceConfiguration {
                 String[] lines = getIOSDeviceID.split("\n");
                 for (int i = 0; i < lines.length; i++) {
                     lines[i] = lines[i].replaceAll("\\s+", "");
-                    devices.put("deviceID" + i, lines[i]);
+                    if (validDeviceIds == null 
+                            || (validDeviceIds != null && validDeviceIds.contains(lines[i]))) {
+                        devices.put("deviceID" + i, lines[i]);
+                    }
                 }
                 return devices;
             }
@@ -250,5 +260,9 @@ public class IOSDeviceConfiguration {
                 System.out.println("iOSWebKitProxyLauncher File already has access to execute");
             }
         }
+    }
+
+    public void setValidDevices(List<String> validDeviceIds) {
+        this.validDeviceIds = validDeviceIds;
     }
 }

--- a/src/main/java/com/appium/manager/AppiumParallelTest.java
+++ b/src/main/java/com/appium/manager/AppiumParallelTest.java
@@ -55,6 +55,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -152,7 +153,7 @@ public class AppiumParallelTest extends TestListenerAdapter implements ITestList
     }
 
     public synchronized AppiumServiceBuilder startAppiumServer(
-            String device, String methodName,String tag) throws Exception {
+            String device, String methodName,String[] tags) throws Exception {
         if (prop.containsKey("CI_BASE_URI")) {
             CI_BASE_URI = prop.getProperty("CI_BASE_URI").toString().trim();
         } else if (CI_BASE_URI == null || CI_BASE_URI.isEmpty()) {
@@ -176,13 +177,10 @@ public class AppiumParallelTest extends TestListenerAdapter implements ITestList
         } else {
             category = androidDevice.getDeviceModel(device_udid);
         }
-        System.out.println("******" + tag.isEmpty() + "::::" + tag);
-        ExtentTest extentTest = tag.isEmpty()
-                ? createParentNodeExtent(methodName, "", category
-                + device_udid.replaceAll("\\W", "_")) :
-
-                createParentNodeExtent(methodName, "", category
-                        + device_udid.replaceAll("\\W", "_")).assignCategory(tag);
+        System.out.println("******Tags::::" + Arrays.toString(tags));
+        //System.out.println("******" + tag.isEmpty() + "::::" + tag);
+        ExtentTest extentTest = createParentNodeExtent(methodName, "", category
+                        + device_udid.replaceAll("\\W", "_")).assignCategory(tags);
 
         AppiumServiceBuilder appiumServiceBuilder = checkOSAndStartServer(methodName);
         if (appiumServiceBuilder != null) {
@@ -299,11 +297,9 @@ public class AppiumParallelTest extends TestListenerAdapter implements ITestList
     }
 
     public AppiumParallelTest createChildNodeWithCategory(String methodName,
-                                                          String tag) {
-        child = tag.isEmpty() ? parentTest.get().createNode(methodName, category
-                + device_udid.replaceAll("\\W", "_")) :
-                parentTest.get().createNode(methodName, category
-                        + device_udid.replaceAll("\\W", "_")).assignCategory(tag);
+                                                          String[] tags) {
+        child = parentTest.get().createNode(methodName, category
+                        + device_udid.replaceAll("\\W", "_")).assignCategory(tags);
         test.set(child);
         return this;
     }

--- a/src/main/java/com/appium/manager/AppiumParallelTest.java
+++ b/src/main/java/com/appium/manager/AppiumParallelTest.java
@@ -64,7 +64,7 @@ public class AppiumParallelTest extends TestListenerAdapter implements ITestList
     public static ArrayList<String> devices = new ArrayList<String>();
     public ConfigurationManager prop;
     public IOSDeviceConfiguration iosDevice;
-    public static AndroidDeviceConfiguration androidDevice = new AndroidDeviceConfiguration();
+    public AndroidDeviceConfiguration androidDevice;
     public static ConcurrentHashMap<String, Boolean> deviceMapping =
             new ConcurrentHashMap<String, Boolean>();
     public AppiumDriver<MobileElement> driver = null;
@@ -93,23 +93,20 @@ public class AppiumParallelTest extends TestListenerAdapter implements ITestList
                     System.out.println("Adding iOS devices");
                     devices.addAll(IOSDeviceConfiguration.deviceUDIDiOS);
                 }
-                if (androidDevice.getDeviceSerial() != null) {
+                if (AndroidDeviceConfiguration.deviceSerial != null) {
                     System.out.println("Adding Android devices");
-                    devices.addAll(AndroidDeviceConfiguration.deviceSerail);
+                    devices.addAll(AndroidDeviceConfiguration.deviceSerial);
                 }
             } else {
-                if (androidDevice.getDeviceSerial() != null) {
+                if (AndroidDeviceConfiguration.deviceSerial != null) {
                     System.out.println("Adding Android devices");
-                    devices.addAll(AndroidDeviceConfiguration.deviceSerail);
+                    devices.addAll(AndroidDeviceConfiguration.deviceSerial);
                 }
             }
             for (String device : devices) {
                 deviceMapping.put(device, true);
             }
             System.out.println(deviceMapping);
-        } catch (IOException e) {
-            e.printStackTrace();
-            System.out.println("Failed to initialize framework");
         } catch (Exception e) {
             e.printStackTrace();
             System.out.println("Failed to initialize framework");
@@ -119,6 +116,7 @@ public class AppiumParallelTest extends TestListenerAdapter implements ITestList
     public AppiumParallelTest() {
         try {
             iosDevice = new IOSDeviceConfiguration();
+            androidDevice = new AndroidDeviceConfiguration();
             appiumMan = new AppiumManager();
             prop = ConfigurationManager.getInstance();
         } catch (IOException e) {
@@ -620,7 +618,6 @@ public class AppiumParallelTest extends TestListenerAdapter implements ITestList
         androidCapabilities.setCapability(AndroidMobileCapabilityType.APP_PACKAGE,
                 prop.getProperty("APP_PACKAGE"));
         androidCapabilities.setCapability("browserName", "");
-        checkSelendroid(androidCapabilities);
         androidCapabilities
                 .setCapability(MobileCapabilityType.APP, prop.getProperty("ANDROID_APP_PATH"));
         androidCapabilities.setCapability(MobileCapabilityType.UDID, device_udid);

--- a/src/main/java/com/appium/manager/ParallelThread.java
+++ b/src/main/java/com/appium/manager/ParallelThread.java
@@ -13,7 +13,6 @@ import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 
-
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -42,11 +41,17 @@ public class ParallelThread {
     private MyTestExecutor myTestExecutor = new MyTestExecutor();
     List<Class> testcases;
     private HtmlReporter htmlReporter = new HtmlReporter();
-
+    
     public ParallelThread() throws IOException {
         configurationManager = ConfigurationManager.getInstance();
     }
 
+    public ParallelThread(List<String> validDeviceIds) throws IOException {
+        configurationManager = ConfigurationManager.getInstance();
+        deviceConf.setValidDevices(validDeviceIds);
+        iosDevice.setValidDevices(validDeviceIds);
+    }
+    
     public boolean runner(String pack, List<String> tests) throws Exception {
         figlet(configurationManager.getProperty("RUNNER"));
         return triggerTest(pack, tests);

--- a/src/main/java/com/appium/utils/CommandPrompt.java
+++ b/src/main/java/com/appium/utils/CommandPrompt.java
@@ -13,9 +13,8 @@ import java.util.Map;
 
 public class CommandPrompt {
 
-    static Process p;
+    Process p;
     ProcessBuilder builder;
-
 
     public String runCommand(String command) throws InterruptedException, IOException {
         p = Runtime.getRuntime().exec(command);

--- a/src/main/java/com/cucumber/listener/ExtentCucumberFormatter.java
+++ b/src/main/java/com/cucumber/listener/ExtentCucumberFormatter.java
@@ -49,7 +49,7 @@ public class ExtentCucumberFormatter implements Reporter, Formatter {
     public LinkedList<Step> testSteps;
     public AppiumDriver<MobileElement> appium_driver;
     public AppiumParallelTest appiumParallelTest;
-    private AndroidDeviceConfiguration androidDevice = new AndroidDeviceConfiguration();
+    private AndroidDeviceConfiguration androidDevice;
     private IOSDeviceConfiguration iosDevice;
     public String deviceModel;
     public ImageUtils imageUtils = new ImageUtils();
@@ -82,6 +82,7 @@ public class ExtentCucumberFormatter implements Reporter, Formatter {
         appiumParallelTest = new AppiumParallelTest();
         try {
             iosDevice = new IOSDeviceConfiguration();
+            androidDevice = new AndroidDeviceConfiguration();
             prop = ConfigurationManager.getInstance();
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/com/cucumber/listener/ExtentCucumberFormatter.java
+++ b/src/main/java/com/cucumber/listener/ExtentCucumberFormatter.java
@@ -159,66 +159,43 @@ public class ExtentCucumberFormatter implements Reporter, Formatter {
 
     }
 
+
+    
     public void feature(Feature feature) {
         if (prop.getProperty("RUNNER").equalsIgnoreCase("parallel")) {
             AppiumParallelTest.getNextAvailableDeviceId();
             String[] deviceThreadNumber = Thread.currentThread().getName().toString().split("_");
+            String[] tagsArray = getTagArray(feature.getTags());
             System.out.println(deviceThreadNumber);
             System.out.println(Integer.parseInt(deviceThreadNumber[1])
                     + prop.getProperty("RUNNER"));
             System.out.println("Feature Tag Name::" + feature.getTags());
-            if (!feature.getTags().isEmpty()) {
-                for (Tag tag : feature.getTags()) {
-                    System.out.println("TagName::" + getTagName(tag));
-                    try {
-                        appiumParallelTest.startAppiumServer(
-                                xpathXML.parseXML(Integer.parseInt(deviceThreadNumber[1])),
-                                feature.getName(), getTagName(tag));
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            } else {
-                try {
-                    appiumParallelTest.startAppiumServer(
-                            xpathXML.parseXML(Integer.parseInt(deviceThreadNumber[1])),
-                            feature.getName(), "");
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+            try {
+                appiumParallelTest.startAppiumServer(
+                        xpathXML.parseXML(Integer.parseInt(deviceThreadNumber[1])), 
+                        feature.getName(),
+                        tagsArray);
+            } catch (Exception e) {
+                e.printStackTrace();
             }
-
         } else {
-            if (!feature.getTags().isEmpty()) {
-                for (Tag tag : feature.getTags()) {
-                    try {
-                        appiumParallelTest.startAppiumServer("", feature.getName(),
-                                getTagName(tag));
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            } else {
-                try {
-                    appiumParallelTest.startAppiumServer("", feature.getName(),
-                            "");
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+            String[] tagsArray = getTagArray(feature.getTags());
+            try {
+                appiumParallelTest.startAppiumServer("", feature.getName(), tagsArray);
+            } catch (Exception e) {
+                e.printStackTrace();
             }
         }
     }
 
-    public String getTagName(Tag tag) {
-        String tagName;
-        if (tag.getName().isEmpty()) {
-            tagName = "";
-        } else {
-            tagName = tag.getName();
+    private String[] getTagArray(List<Tag> tags) {
+        String[] tagArray = new String[tags.size()];
+        for (int i = 0; i < tags.size(); i++) {
+            tagArray[i] = tags.get(i).getName();
         }
-        return tagName;
+        return tagArray;
     }
-
+    
     public void scenarioOutline(ScenarioOutline scenarioOutline) {
 
     }
@@ -234,26 +211,16 @@ public class ExtentCucumberFormatter implements Reporter, Formatter {
     }
 
     public void createAppiumInstance(Scenario scenario) {
-        if (!scenario.getTags().isEmpty()) {
-            for (Tag tag : scenario.getTags()) {
-                try {
-                    startAppiumServer(scenario, tag.getName());
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
-            }
-
-        } else {
-            try {
-                startAppiumServer(scenario, "");
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+        String[] tagsArray = getTagArray(scenario.getTags());
+        try {
+            startAppiumServer(scenario, tagsArray);
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 
-    public void startAppiumServer(Scenario scenario, String tag) throws Exception {
-        appium_driver = appiumParallelTest.createChildNodeWithCategory(scenario.getName(),tag)
+    public void startAppiumServer(Scenario scenario, String[] tags) throws Exception {
+        appium_driver = appiumParallelTest.createChildNodeWithCategory(scenario.getName(), tags)
                 .startAppiumServerInParallel("",
                         iosCapabilities, androidCapabilities);
         setWebDriver(appium_driver);

--- a/src/test/java/com/test/cucumber/stepdefinitions/Hooks.java
+++ b/src/test/java/com/test/cucumber/stepdefinitions/Hooks.java
@@ -18,8 +18,6 @@ import java.io.IOException;
 public class Hooks extends ExtentCucumberFormatter {
     @Before public void beforeClass(Scenario scenario) throws Exception {
         System.out.println("Inside Before" + Thread.currentThread().getId());
-        iosCapabilities = appiumParallelTest.iosNative();
-        androidCapabilities = appiumParallelTest.androidNative();
     }
 
     @After public void afterClass(Scenario scenario) throws InterruptedException, IOException {


### PR DESCRIPTION
This PR adds support for passing in a list of device ids to the test runner so that only specified devices (and not all connected devices) will run.  Also fixed some issues with a static AndroidConfiguration that had problems with using adb commands and some spelling/formatting fixes.

Example test runner:

```
public class RunnerCukes {
    @Test 
    public void testCukesRunner() throws Exception {
    	List<String> deviceList = Arrays.asList("udid1", "udid2", "udid3");
    	ParallelThread cucumberParallelThread = new ParallelThread(deviceList);
        boolean hasFailures = cucumberParallelThread.runner("output");
        Assert.assertFalse(hasFailures, "Testcases have failed in parallel execution");
    }
}
```

Please let me know if it has any issues.