### PR TITLE
Fixing iOS version read

### DIFF
--- a/src/main/java/com/appium/ios/IOSDeviceConfiguration.java
+++ b/src/main/java/com/appium/ios/IOSDeviceConfiguration.java
@@ -162,7 +162,7 @@ public class IOSDeviceConfiguration {
             return commandPrompt
                     .runCommandThruProcessBuilder("ideviceinfo --udid "
                             + DeviceManager.getDeviceUDID()
-                            + " | grep ProductVersion").split(":")[1].replace("\n", "");
+                            + " | grep ProductVersion").replace("\n", "");
         } else {
             return simulatorManager.getSimulatorDetails(DeviceManager.getDeviceUDID())
                     .getOsVersion();

--- a/src/main/java/com/appium/utils/DesiredCapabilityBuilder.java
+++ b/src/main/java/com/appium/utils/DesiredCapabilityBuilder.java
@@ -73,8 +73,8 @@ public class DesiredCapabilityBuilder {
             }
             appPackage(desiredCapabilities);
         } else if (DeviceManager.getMobilePlatform().equals(MobilePlatform.IOS)) {
+            String version = iosDevice.getIOSDeviceProductVersion();
             appPackageBundle(desiredCapabilities);
-
             //Check if simulator.json exists and add the deviceName and OS
             if (DeviceManager.getDeviceUDID().length() == IOSDeviceConfiguration.SIM_UDID_LENGTH) {
                 desiredCapabilities.setCapability(MobileCapabilityType.DEVICE_NAME,
@@ -85,7 +85,7 @@ public class DesiredCapabilityBuilder {
                         simulatorManager.getSimulatorDetailsFromUDID(DeviceManager.getDeviceUDID(),
                                 "iOS").getOsVersion());
             }
-            if (Float.valueOf(iosDevice.getIOSDeviceProductVersion()) >= 10.0) {
+            if (Float.valueOf(version.substring(0, version.length() - 2)) >= 10.0) {
                 desiredCapabilities.setCapability(MobileCapabilityType.AUTOMATION_NAME,
                         AutomationName.IOS_XCUI_TEST);
                 desiredCapabilities.setCapability(IOSMobileCapabilityType


### PR DESCRIPTION
Fixing iOS version read - To compare only first two digits of the iOS version. Tested on couple of devices