### PR TITLE
Reporting changes with user specified screenshots

### DIFF
--- a/src/main/java/com/appium/utils/GenerateReportJson.java
+++ b/src/main/java/com/appium/utils/GenerateReportJson.java
@@ -1,7 +1,6 @@
 package com.appium.utils;
 
 
-import com.annotation.values.Description;
 import com.appium.manager.AppiumDriverManager;
 import com.appium.manager.DeviceManager;
 import org.json.JSONArray;
@@ -21,8 +20,7 @@ import java.util.*;
 public class GenerateReportJson {
 
     AppiumDriverManager appiumDriverManager;
-
-    public List<String> syncal =
+    public static List<String> syncal =
             Collections.synchronizedList(new ArrayList<String>());
 
     public static Map<String, String> userLogs =
@@ -93,6 +91,7 @@ public class GenerateReportJson {
         JSONObject jsonReport = new JSONObject();
         JSONArray jsonTest = new JSONArray();
         JSONParser parser = new JSONParser();
+
         for (int i = 0; i < syncal.size(); i++) {
             try {
                 jsonTest.put(parser.parse(syncal.get(i)));
@@ -106,6 +105,13 @@ public class GenerateReportJson {
 
         jsonReport.put("summary", summaryDetails);
         jsonReport.put("tests", jsonTest);
+        JSONParser jsonParser = new JSONParser();
+        try {
+            jsonReport.put("Screenshots", jsonParser.parse(ScreenShotManager.synmap.get("captureScreenShot")));
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+
         try {
             userLogs.put("Appium", "1.6.6.beta4");
             jsonReport.put("userMetaData", userLogs);
@@ -118,12 +124,11 @@ public class GenerateReportJson {
 
     public void getTestResultsAndQuitDriver(IInvokedMethod method, ITestResult testResult) {
         ScreenShotManager screenShotManager = new ScreenShotManager();
-        HashMap<String,String> logs = new HashMap<>();
+        HashMap<String, String> logs = new HashMap<>();
         JSONObject json = new JSONObject();
         json.put("id", DeviceManager.getDeviceUDID());
         json.put("version", new DeviceManager().getDeviceVersion());
         json.put("platform", DeviceManager.getMobilePlatform());
-        //json.put("resolution", DeviceManager.getMobilePlatform());
         try {
             json.put("model", new DeviceManager().getDeviceModel());
         } catch (InterruptedException e) {
@@ -134,7 +139,7 @@ public class GenerateReportJson {
         try {
             if (testResult.getStatus() == ITestResult.SUCCESS
                     || testResult.getStatus() == ITestResult.FAILURE) {
-                if(testResult.getStatus() == ITestResult.FAILURE) {
+                if (testResult.getStatus() == ITestResult.FAILURE) {
                     screenShotManager.captureScreenShot(2,
                             testResult.getClass().getSimpleName(),
                             testResult.getMethod().getMethodName());
@@ -142,11 +147,11 @@ public class GenerateReportJson {
                     if (new File(System.getProperty("user.dir")
                             + "/target/" + screenShotManager.getFailedScreen()).exists()) {
                         screenShotFailure = screenShotManager.getFailedScreen();
-                        logs.put("screenShotFailure",screenShotFailure);
+                        logs.put("screenShotFailure", screenShotFailure);
                     } else if (new File(System.getProperty("user.dir")
                             + "/target/" + screenShotManager.getFramedFailedScreen()).exists()) {
                         screenShotFailure = screenShotManager.getFramedFailedScreen();
-                        logs.put("screenShotFailure",screenShotFailure);
+                        logs.put("screenShotFailure", screenShotFailure);
                     }
                 }
                 String testDescription;
@@ -156,7 +161,7 @@ public class GenerateReportJson {
                 } else {
                     testDescription = description;
                 }
-                JSONObject status = getStatus(json,logs,
+                JSONObject status = getStatus(json, logs,
                         getExecutionStatus(testResult),
                         String.valueOf(testResult.getThrowable()),
                         testDescription,
@@ -193,7 +198,7 @@ public class GenerateReportJson {
         return getResultsSummary(results);
     }
 
-    private void sync(String message) {
+    public void sync(String message) {
         //Adding elements to synchronized ArrayList
         syncal.add(message);
     }

--- a/src/main/java/com/appium/utils/GenerateReportJson.java
+++ b/src/main/java/com/appium/utils/GenerateReportJson.java
@@ -105,10 +105,18 @@ public class GenerateReportJson {
 
         jsonReport.put("summary", summaryDetails);
         jsonReport.put("tests", jsonTest);
+        JSONObject jsonObject = new JSONObject();
         JSONParser jsonParser = new JSONParser();
         try {
-            jsonReport.put("Screenshots", jsonParser.parse(ScreenShotManager.synmap.get("captureScreenShot")));
-        } catch (ParseException e) {
+            ScreenShotManager.synmap.forEach((s, s2) -> {
+                try {
+                    jsonObject.put(s,jsonParser.parse(s2));
+                } catch (ParseException e) {
+                    e.printStackTrace();
+                }
+            });
+            jsonReport.put("Screenshots",jsonObject);
+        } catch (Exception e) {
             e.printStackTrace();
         }
 

--- a/src/main/java/com/appium/utils/GenerateReportJson.java
+++ b/src/main/java/com/appium/utils/GenerateReportJson.java
@@ -105,17 +105,17 @@ public class GenerateReportJson {
 
         jsonReport.put("summary", summaryDetails);
         jsonReport.put("tests", jsonTest);
-        JSONObject jsonObject = new JSONObject();
+        JSONArray jsonArray = new JSONArray();
         JSONParser jsonParser = new JSONParser();
         try {
             ScreenShotManager.synmap.forEach((s, s2) -> {
                 try {
-                    jsonObject.put(s,jsonParser.parse(s2));
+                    jsonArray.put(jsonParser.parse(s2));
                 } catch (ParseException e) {
                     e.printStackTrace();
                 }
             });
-            jsonReport.put("Screenshots",jsonObject);
+            jsonReport.put("Screenshots",jsonArray);
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/com/appium/utils/GenerateReportJson.java
+++ b/src/main/java/com/appium/utils/GenerateReportJson.java
@@ -163,7 +163,8 @@ public class GenerateReportJson {
                     }
                 }
                 String testDescription;
-                String description = method.getTestMethod().getMethod().getAnnotation(Test.class).description();
+                String description = method.getTestMethod().getMethod()
+                        .getAnnotation(Test.class).description();
                 if (description.isEmpty()) {
                     testDescription = method.getTestMethod().getMethodName();
                 } else {

--- a/src/main/java/com/appium/utils/ScreenShotManager.java
+++ b/src/main/java/com/appium/utils/ScreenShotManager.java
@@ -34,14 +34,12 @@ public class ScreenShotManager {
 
     JSONObject screenshotDetails = new JSONObject();
     JSONObject logs = new JSONObject();
-    ;
 
     public static HashMap<String, String> syncal =
             new HashMap<>();
 
     public static Map<String, String> synmap
             = Collections.synchronizedMap(syncal);
-    ;
 
     public ScreenShotManager() {
         imageUtils = new ImageUtils();
@@ -130,7 +128,7 @@ public class ScreenShotManager {
         String className = new Exception().getStackTrace()[1].getClassName();
         String methodName = new Exception().getStackTrace()[1].getMethodName();
 
-        String s = captureScreenShot(1, className, methodName,screenShotName);
+        captureScreenShot(1, className, methodName,screenShotName);
 
         new File(System.getProperty("user.dir")
                 + "/target/" + getCapturedScreen());

--- a/src/main/java/com/appium/utils/ScreenShotManager.java
+++ b/src/main/java/com/appium/utils/ScreenShotManager.java
@@ -17,7 +17,9 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by saikrisv on 26/04/17.
@@ -32,16 +34,19 @@ public class ScreenShotManager {
     private String framedCapturedScreen;
     JSONArray screenShotArray = new JSONArray();
     JSONObject screenshotDetails = new JSONObject();
-    JSONObject logs = new JSONObject();;
+    JSONObject logs = new JSONObject();
+    ;
 
-    public HashMap<String,String> syncal =
+    public static HashMap<String, String> syncal =
             new HashMap<>();
 
 //    public Map<String, String> getSynmap() {
 //        return synmap;
 //    }
 
-    public static Map<String,String> synmap;
+    public static Map<String, String> synmap
+            = Collections.synchronizedMap(syncal);
+    ;
 
     public ScreenShotManager() {
         imageUtils = new ImageUtils();
@@ -105,34 +110,32 @@ public class ScreenShotManager {
             throws InterruptedException, IOException {
         String json = null;
         String className = new Exception().getStackTrace()[1].getClassName();
-//        String methodName = new Exception().getStackTrace()[1].getMethodName();
+        String methodName = new Exception().getStackTrace()[1].getMethodName();
         JSONObject jsonObj1 = new JSONObject();
 
-        String s = captureScreenShot(1, className, screenShotName);
+        String s = captureScreenShot(1, className, methodName);
         new File(System.getProperty("user.dir")
                 + "/target/" + screenShotName + getCapturedScreen());
 //        jsonObj.put(className + "." + methodName, screenShotName + s);
 //        screenShots.put(jsonObj);
 
-        if(screenshotDetails.length()<=0) {
+        if (screenshotDetails.length() <= 0) {
             screenshotDetails = getScreenshotDetails();
         }
-
         logs.put(screenShotName, System.getProperty("user.dir") + "/target/" + s);
         //screenshotDetails.remove("screens");
-        screenshotDetails.put("screens",logs);
-        if (syncal.containsKey(screenshotDetails.get("method_name").toString())) {
-            syncal.put(screenshotDetails.get("method_name").toString()+"",
+        screenshotDetails.put("screens", logs);
+        if (syncal.containsKey(className+methodName)) {
+            syncal.put(className+methodName,
                     screenshotDetails.toString());
         }
-        syncal.put(screenshotDetails.get("method_name").toString()+"",
+        syncal.put(className+methodName,
                 screenshotDetails.toString());
-         synmap = Collections.synchronizedMap(syncal);
     }
 
     private JSONObject getScreenshotDetails() {
-        String className = new Exception().getStackTrace()[1].getClassName();
-        String methodName = new Exception().getStackTrace()[1].getMethodName();
+        String className = new Exception().getStackTrace()[2].getClassName();
+        String methodName = new Exception().getStackTrace()[2].getMethodName();
 //        JSONObject jsonObj = new JSONObject();
         JSONObject jsonObj1 = new JSONObject();
 //        jsonObj.put(className + "." + methodName, screenShotName + s);

--- a/src/main/java/com/appium/utils/ScreenShotManager.java
+++ b/src/main/java/com/appium/utils/ScreenShotManager.java
@@ -5,7 +5,6 @@ import com.appium.manager.AppiumDriverManager;
 import com.appium.manager.DeviceManager;
 import org.apache.commons.io.FileUtils;
 import org.im4java.core.IM4JavaException;
-import org.json.JSONArray;
 import org.json.JSONObject;
 import org.openqa.selenium.OutputType;
 import org.testng.ITestResult;
@@ -32,17 +31,13 @@ public class ScreenShotManager {
     private String failedScreen;
     private String framedFailedScreen;
     private String framedCapturedScreen;
-    JSONArray screenShotArray = new JSONArray();
+
     JSONObject screenshotDetails = new JSONObject();
     JSONObject logs = new JSONObject();
     ;
 
     public static HashMap<String, String> syncal =
             new HashMap<>();
-
-//    public Map<String, String> getSynmap() {
-//        return synmap;
-//    }
 
     public static Map<String, String> synmap
             = Collections.synchronizedMap(syncal);
@@ -106,40 +101,57 @@ public class ScreenShotManager {
         return getDeviceModel;
     }
 
+    public String captureScreenShot(int status, String className,
+                                    String methodName, String screenShotName)
+            throws IOException, InterruptedException {
+
+        String getDeviceModel = null;
+        System.out.println("Current Running Thread Status"
+                + AppiumDriverManager.getDriver().getSessionId());
+        File scrFile = AppiumDriverManager.getDriver()
+                .getScreenshotAs(OutputType.FILE);
+        screenShotNameWithTimeStamp = currentDateAndTime();
+        if (DeviceManager.getMobilePlatform().equals(MobilePlatform.ANDROID)) {
+            getDeviceModel = screenShotNameWithTimeStamp;
+            screenShotAndFrame(status, scrFile, methodName, className, getDeviceModel,
+                    "android", screenShotName);
+        } else if (DeviceManager.getMobilePlatform().equals(MobilePlatform.IOS)) {
+            getDeviceModel = screenShotNameWithTimeStamp;
+            screenShotAndFrame(status, scrFile, methodName, className, getDeviceModel,
+                    "iOS", screenShotName);
+        }
+        return getDeviceModel;
+    }
+
+
     public void captureScreenShot(String screenShotName)
             throws InterruptedException, IOException {
-        String json = null;
+
         String className = new Exception().getStackTrace()[1].getClassName();
         String methodName = new Exception().getStackTrace()[1].getMethodName();
-        JSONObject jsonObj1 = new JSONObject();
 
-        String s = captureScreenShot(1, className, methodName);
+        String s = captureScreenShot(1, className, methodName,screenShotName);
+
         new File(System.getProperty("user.dir")
-                + "/target/" + screenShotName + getCapturedScreen());
-//        jsonObj.put(className + "." + methodName, screenShotName + s);
-//        screenShots.put(jsonObj);
+                + "/target/" + getCapturedScreen());
 
         if (screenshotDetails.length() <= 0) {
             screenshotDetails = getScreenshotDetails();
         }
-        logs.put(screenShotName, System.getProperty("user.dir") + "/target/" + s);
-        //screenshotDetails.remove("screens");
+
+        logs.put(screenShotName, getCapturedScreen());
         screenshotDetails.put("screens", logs);
-        if (syncal.containsKey(className+methodName)) {
-            syncal.put(className+methodName,
-                    screenshotDetails.toString());
-        }
-        syncal.put(className+methodName,
+
+        syncal.put(className + methodName + DeviceManager.getDeviceUDID(),
                 screenshotDetails.toString());
     }
 
     private JSONObject getScreenshotDetails() {
         String className = new Exception().getStackTrace()[2].getClassName();
+        className = className.split("\\.")[className.split("\\.").length - 1];
         String methodName = new Exception().getStackTrace()[2].getMethodName();
-//        JSONObject jsonObj = new JSONObject();
         JSONObject jsonObj1 = new JSONObject();
-//        jsonObj.put(className + "." + methodName, screenShotName + s);
-//        screenShots.put(jsonObj);
+
         jsonObj1.put("class_name", className);
         jsonObj1.put("method_name", methodName);
         try {
@@ -179,6 +191,90 @@ public class ScreenShotManager {
                         + "/" + methodName + "/"
                         + screenShotNameWithTimeStamp + "_"
                         + methodName + "_results.jpeg");
+
+        setFramedCapturedScreen("screenshot/" + platform + "/" + DeviceManager.getDeviceUDID()
+                + "/" + className
+                + "/" + methodName + "/" + model + "_"
+                + methodName + "_results_framed.jpeg");
+        setFramedFailedScreen(
+                "screenshot/" + platform + "/" + DeviceManager.getDeviceUDID()
+                        + "/" + className
+                        + "/" + methodName + "/" + model
+                        + "_failed_" + methodName + "_framed.jpeg");
+
+        try {
+            File framePath =
+                    new File(System.getProperty("user.dir")
+                            + "/src/test/resources/frames/");
+            if (status == ITestResult.FAILURE) {
+                FileUtils.copyFile(scrFile, new File(System.getProperty("user.dir")
+                        + "/target/" + getFailedScreen().trim()));
+            } else {
+                FileUtils.copyFile(scrFile, new File(System.getProperty("user.dir")
+                        + "/target/" + getCapturedScreen().trim()));
+            }
+
+            File[] files1 = framePath.listFiles();
+            if (framePath.exists()) {
+                for (int i = 0; i < files1.length; i++) {
+                    if (files1[i].isFile()) { //this line weeds out other directories/folders
+                        System.out.println(files1[i]);
+
+                        Path p = Paths.get(files1[i].toString());
+                        String fileName = p.getFileName().toString().toLowerCase();
+                        if (model.toLowerCase()
+                                .contains(fileName.split(".png")[0].toLowerCase())) {
+                            try {
+                                if (status == ITestResult.FAILURE) {
+                                    String screenToFrame = System.getProperty("user.dir")
+                                            + "/target/" + getFailedScreen();
+                                    imageUtils.wrapDeviceFrames(files1[i].toString(), screenToFrame,
+                                            System.getProperty("user.dir")
+                                                    + "/target/" + getFramedFailedScreen());
+                                    deleteFile(screenToFrame);
+                                } else {
+                                    String screenToFrame = System.getProperty("user.dir")
+                                            + "/target/" + getCapturedScreen();
+                                    imageUtils.wrapDeviceFrames(files1[i].toString(), screenToFrame,
+                                            System.getProperty("user.dir")
+                                                    + "/target/" + getFramedCapturedScreen());
+                                    deleteFile(screenToFrame);
+                                }
+
+                                break;
+                            } catch (InterruptedException e) {
+                                e.printStackTrace();
+                            } catch (IM4JavaException e) {
+                                e.printStackTrace();
+                            }
+                        }
+                    }
+                }
+            }
+
+        } catch (IOException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+    }
+
+
+    private void screenShotAndFrame(int status,
+                                    File scrFile, String methodName,
+                                    String className, String model,
+                                    String platform, String screenShotName) {
+        setFailedScreen(
+                "screenshot/" + platform + "/" + DeviceManager.getDeviceUDID()
+                        + "/" + className + "/"
+                        + methodName + "/"
+                        + screenShotNameWithTimeStamp + "_"
+                        + methodName + "_failed" + ".jpeg");
+        setCapturedScreen(
+                "screenshot/" + platform + "/" + DeviceManager.getDeviceUDID()
+                        + "/" + className
+                        + "/" + methodName + "/"
+                        + screenShotNameWithTimeStamp + "_"
+                        + methodName + "-" + screenShotName + "_results.jpeg");
 
         setFramedCapturedScreen("screenshot/" + platform + "/" + DeviceManager.getDeviceUDID()
                 + "/" + className

--- a/src/main/java/com/appium/utils/ScreenShotManager.java
+++ b/src/main/java/com/appium/utils/ScreenShotManager.java
@@ -1,12 +1,12 @@
 package com.appium.utils;
 
-import com.appium.android.AndroidDeviceConfiguration;
 import com.appium.entities.MobilePlatform;
-import com.appium.ios.IOSDeviceConfiguration;
 import com.appium.manager.AppiumDriverManager;
 import com.appium.manager.DeviceManager;
 import org.apache.commons.io.FileUtils;
 import org.im4java.core.IM4JavaException;
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.openqa.selenium.OutputType;
 import org.testng.ITestResult;
 
@@ -17,6 +17,7 @@ import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.util.*;
 
 /**
  * Created by saikrisv on 26/04/17.
@@ -29,6 +30,22 @@ public class ScreenShotManager {
     private String failedScreen;
     private String framedFailedScreen;
     private String framedCapturedScreen;
+    JSONArray screenShotArray = new JSONArray();
+    JSONObject screenshotDetails = new JSONObject();
+    JSONObject logs = new JSONObject();;
+
+    public HashMap<String,String> syncal =
+            new HashMap<>();
+
+//    public Map<String, String> getSynmap() {
+//        return synmap;
+//    }
+
+    public static Map<String,String> synmap;
+
+    public ScreenShotManager() {
+        imageUtils = new ImageUtils();
+    }
 
     public String getFramedCapturedScreen() {
         return framedCapturedScreen;
@@ -62,11 +79,6 @@ public class ScreenShotManager {
         this.failedScreen = failedScreen;
     }
 
-
-    public ScreenShotManager() {
-        imageUtils = new ImageUtils();
-    }
-
     public String captureScreenShot(int status, String className,
                                     String methodName)
             throws IOException, InterruptedException {
@@ -91,10 +103,55 @@ public class ScreenShotManager {
 
     public void captureScreenShot(String screenShotName)
             throws InterruptedException, IOException {
+        String json = null;
         String className = new Exception().getStackTrace()[1].getClassName();
-        captureScreenShot(1, className, screenShotName);
+//        String methodName = new Exception().getStackTrace()[1].getMethodName();
+        JSONObject jsonObj1 = new JSONObject();
+
+        String s = captureScreenShot(1, className, screenShotName);
+        new File(System.getProperty("user.dir")
+                + "/target/" + screenShotName + getCapturedScreen());
+//        jsonObj.put(className + "." + methodName, screenShotName + s);
+//        screenShots.put(jsonObj);
+
+        if(screenshotDetails.length()<=0) {
+            screenshotDetails = getScreenshotDetails();
+        }
+
+        logs.put(screenShotName, System.getProperty("user.dir") + "/target/" + s);
+        //screenshotDetails.remove("screens");
+        screenshotDetails.put("screens",logs);
+        if (syncal.containsKey(screenshotDetails.get("method_name").toString())) {
+            syncal.put(screenshotDetails.get("method_name").toString()+"",
+                    screenshotDetails.toString());
+        }
+        syncal.put(screenshotDetails.get("method_name").toString()+"",
+                screenshotDetails.toString());
+         synmap = Collections.synchronizedMap(syncal);
     }
 
+    private JSONObject getScreenshotDetails() {
+        String className = new Exception().getStackTrace()[1].getClassName();
+        String methodName = new Exception().getStackTrace()[1].getMethodName();
+//        JSONObject jsonObj = new JSONObject();
+        JSONObject jsonObj1 = new JSONObject();
+//        jsonObj.put(className + "." + methodName, screenShotName + s);
+//        screenShots.put(jsonObj);
+        jsonObj1.put("class_name", className);
+        jsonObj1.put("method_name", methodName);
+        try {
+            jsonObj1.put("model", new DeviceManager().getDeviceModel());
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        jsonObj1.put("id", DeviceManager.getDeviceUDID());
+        jsonObj1.put("version", new DeviceManager().getDeviceVersion());
+        jsonObj1.put("platform", DeviceManager.getMobilePlatform());
+
+        return jsonObj1;
+    }
 
     private String currentDateAndTime() {
         LocalDateTime now = LocalDateTime.now();
@@ -108,22 +165,22 @@ public class ScreenShotManager {
                                     String className, String model,
                                     String platform) {
         setFailedScreen(
-                  "screenshot/" + platform + "/" + DeviceManager.getDeviceUDID()
+                "screenshot/" + platform + "/" + DeviceManager.getDeviceUDID()
                         + "/" + className + "/"
                         + methodName + "/"
-                        + screenShotNameWithTimeStamp  + "_"
+                        + screenShotNameWithTimeStamp + "_"
                         + methodName + "_failed" + ".jpeg");
         setCapturedScreen(
                 "screenshot/" + platform + "/" + DeviceManager.getDeviceUDID()
                         + "/" + className
                         + "/" + methodName + "/"
-                        + screenShotNameWithTimeStamp  + "_"
+                        + screenShotNameWithTimeStamp + "_"
                         + methodName + "_results.jpeg");
 
         setFramedCapturedScreen("screenshot/" + platform + "/" + DeviceManager.getDeviceUDID()
-                        + "/" + className
-                        + "/" + methodName + "/" + model + "_"
-                        + methodName + "_results_framed.jpeg");
+                + "/" + className
+                + "/" + methodName + "/" + model + "_"
+                + methodName + "_results_framed.jpeg");
         setFramedFailedScreen(
                 "screenshot/" + platform + "/" + DeviceManager.getDeviceUDID()
                         + "/" + className
@@ -165,7 +222,7 @@ public class ScreenShotManager {
                                             + "/target/" + getCapturedScreen();
                                     imageUtils.wrapDeviceFrames(files1[i].toString(), screenToFrame,
                                             System.getProperty("user.dir")
-                                                    + "/target/" +  getFramedCapturedScreen());
+                                                    + "/target/" + getFramedCapturedScreen());
                                     deleteFile(screenToFrame);
                                 }
 

--- a/src/main/java/com/appium/utils/ScreenShotManager.java
+++ b/src/main/java/com/appium/utils/ScreenShotManager.java
@@ -1,6 +1,5 @@
 package com.appium.utils;
 
-import com.appium.entities.MobilePlatform;
 import com.appium.manager.AppiumDriverManager;
 import com.appium.manager.DeviceManager;
 import org.apache.commons.io.FileUtils;
@@ -81,44 +80,29 @@ public class ScreenShotManager {
                                     String methodName)
             throws IOException, InterruptedException {
 
-        String getDeviceModel = null;
         System.out.println("Current Running Thread Status"
                 + AppiumDriverManager.getDriver().getSessionId());
         File scrFile = AppiumDriverManager.getDriver()
                 .getScreenshotAs(OutputType.FILE);
         screenShotNameWithTimeStamp = currentDateAndTime();
-        if (DeviceManager.getMobilePlatform().equals(MobilePlatform.ANDROID)) {
-            getDeviceModel = screenShotNameWithTimeStamp;
-            screenShotAndFrame(status, scrFile, methodName, className, getDeviceModel,
-                    "android");
-        } else if (DeviceManager.getMobilePlatform().equals(MobilePlatform.IOS)) {
-            getDeviceModel = screenShotNameWithTimeStamp;
-            screenShotAndFrame(status, scrFile, methodName, className, getDeviceModel,
-                    "iOS");
-        }
-        return getDeviceModel;
+        screenShotAndFrame(status, scrFile, methodName, className, screenShotNameWithTimeStamp,
+                DeviceManager.getMobilePlatform().toString());
+        return screenShotNameWithTimeStamp;
     }
 
     public String captureScreenShot(int status, String className,
                                     String methodName, String screenShotName)
             throws IOException, InterruptedException {
 
-        String getDeviceModel = null;
         System.out.println("Current Running Thread Status"
                 + AppiumDriverManager.getDriver().getSessionId());
         File scrFile = AppiumDriverManager.getDriver()
                 .getScreenshotAs(OutputType.FILE);
         screenShotNameWithTimeStamp = currentDateAndTime();
-        if (DeviceManager.getMobilePlatform().equals(MobilePlatform.ANDROID)) {
-            getDeviceModel = screenShotNameWithTimeStamp;
-            screenShotAndFrame(status, scrFile, methodName, className, getDeviceModel,
-                    "android", screenShotName);
-        } else if (DeviceManager.getMobilePlatform().equals(MobilePlatform.IOS)) {
-            getDeviceModel = screenShotNameWithTimeStamp;
-            screenShotAndFrame(status, scrFile, methodName, className, getDeviceModel,
-                    "iOS", screenShotName);
-        }
-        return getDeviceModel;
+        screenShotAndFrame(status, scrFile, methodName, className, screenShotNameWithTimeStamp,
+                DeviceManager.getMobilePlatform().toString(), screenShotName);
+
+        return screenShotNameWithTimeStamp;
     }
 
 
@@ -128,7 +112,7 @@ public class ScreenShotManager {
         String className = new Exception().getStackTrace()[1].getClassName();
         String methodName = new Exception().getStackTrace()[1].getMethodName();
 
-        captureScreenShot(1, className, methodName,screenShotName);
+        captureScreenShot(1, className, methodName, screenShotName);
 
         new File(System.getProperty("user.dir")
                 + "/target/" + getCapturedScreen());

--- a/src/test/java/com/test/site/HomePageTest2.java
+++ b/src/test/java/com/test/site/HomePageTest2.java
@@ -21,10 +21,12 @@ public class HomePageTest2 {
     public void testMethodOne1() throws Exception {
         ScreenShotManager screenShotManager = new ScreenShotManager();
         Thread.sleep(5000);
-        AppiumDriverManager.getDriver().findElement(By.id("com.android2.calculator3:id/cling_dismiss")).click();
+        AppiumDriverManager.getDriver().findElement(
+                By.id("com.android2.calculator3:id/cling_dismiss")).click();
         screenShotManager.captureScreenShot("first" );
         screenShotManager.captureScreenShot("second" );
-        AppiumDriverManager.getDriver().findElementByAccessibilityId("doubleTap").click();
+        AppiumDriverManager.getDriver()
+                .findElementByAccessibilityId("doubleTap").click();
         Thread.sleep(2000);
         AppiumDriverManager.getDriver().quit();
     }
@@ -34,10 +36,12 @@ public class HomePageTest2 {
     public void testMethodOne2() throws Exception {
         ScreenShotManager screenShotManager = new ScreenShotManager();
         Thread.sleep(5000);
-        AppiumDriverManager.getDriver().findElement(By.id("com.android2.calculator3:id/cling_dismiss")).click();
+        AppiumDriverManager.getDriver().findElement(
+                By.id("com.android2.calculator3:id/cling_dismiss")).click();
         screenShotManager.captureScreenShot("Third" );
         screenShotManager.captureScreenShot("Fourth" );
-        AppiumDriverManager.getDriver().findElementByAccessibilityId("doubleTap").click();
+        AppiumDriverManager.getDriver()
+                .findElementByAccessibilityId("doubleTap").click();
         Thread.sleep(2000);
         AppiumDriverManager.getDriver().quit();
     }

--- a/src/test/java/com/test/site/HomePageTest2.java
+++ b/src/test/java/com/test/site/HomePageTest2.java
@@ -4,7 +4,12 @@ package com.test.site;
 import com.annotation.values.Author;
 import com.annotation.values.Description;
 import com.appium.manager.AppiumDriverManager;
+import com.appium.utils.ScreenShotManager;
+import io.appium.java_client.AppiumDriver;
+import org.openqa.selenium.By;
 import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
 
 
 @Description("This Test validates swipe scenarios")
@@ -14,8 +19,11 @@ public class HomePageTest2 {
     @Test(groups = "smoke", description = "Testing Skips")
     @Author(name = "AnsonLiao")
     public void testMethodOne1() throws Exception {
+        ScreenShotManager screenShotManager = new ScreenShotManager();
         Thread.sleep(5000);
-        AppiumDriverManager.getDriver().findElementByAccessibilityId("login").click();
+        AppiumDriverManager.getDriver().findElement(By.id("com.android2.calculator3:id/cling_dismiss")).click();
+        screenShotManager.captureScreenShot("first" );
+        screenShotManager.captureScreenShot("second" );
         AppiumDriverManager.getDriver().findElementByAccessibilityId("doubleTap").click();
         Thread.sleep(2000);
         AppiumDriverManager.getDriver().quit();
@@ -24,8 +32,11 @@ public class HomePageTest2 {
     @Test(groups = "smoke", description = "Testing Skips")
     @Author(name = "AnsonLiao")
     public void testMethodOne2() throws Exception {
+        ScreenShotManager screenShotManager = new ScreenShotManager();
         Thread.sleep(5000);
-        AppiumDriverManager.getDriver().findElementByAccessibilityId("login").click();
+        AppiumDriverManager.getDriver().findElement(By.id("com.android2.calculator3:id/cling_dismiss")).click();
+        screenShotManager.captureScreenShot("Third" );
+        screenShotManager.captureScreenShot("Fourth" );
         AppiumDriverManager.getDriver().findElementByAccessibilityId("doubleTap").click();
         Thread.sleep(2000);
         AppiumDriverManager.getDriver().quit();


### PR DESCRIPTION
Below is the JSON generated

```
{
  "report": {
    "summary": {
      "duration": 66,
      "suite_name": "TestNG Test0",
      "passed": 0,
      "failed": 2,
      "skipped": 0,
      "num_tests": 2
    },
    "Screenshots": [
      {
        "method_name": "testMethodOne1",
        "screens": {
          "first": "screenshot/android/FA66VBN01980/com.test.site.HomePageTest2/testMethodOne1/2017-10-19T17:23:33_testMethodOne1-first_results.jpeg",
          "second": "screenshot/android/FA66VBN01980/com.test.site.HomePageTest2/testMethodOne1/2017-10-19T17:23:34_testMethodOne1-second_results.jpeg"
        },
        "model": "HTC 10_htc",
        "id": "FA66VBN01980",
        "class_name": "HomePageTest2",
        "version": "6.0.1",
        "platform": "ANDROID"
      },
      {
        "method_name": "testMethodOne2",
        "screens": {
          "Third": "screenshot/android/FA66VBN01980/com.test.site.HomePageTest2/testMethodOne2/2017-10-19T17:24:06_testMethodOne2-Third_results.jpeg",
          "Fourth": "screenshot/android/FA66VBN01980/com.test.site.HomePageTest2/testMethodOne2/2017-10-19T17:24:07_testMethodOne2-Fourth_results.jpeg"
        },
        "model": "HTC 10_htc",
        "id": "FA66VBN01980",
        "class_name": "HomePageTest2",
        "version": "6.0.1",
        "platform": "ANDROID"
      }
    ],
    "tests": [
      {
        "testDetails": {
          "classname": "HomePageTest2",
          "endtime": 1508414015,
          "starttime": 1508413984,
          "results": "Fail",
          "logs": {
            "screenShotFailure": "screenshot/android/FA66VBN01980/TestResult/testMethodOne1/2017-10-19T17:23:36_testMethodOne1_failed.jpeg"
          },
          "exceptiontrace": "org.openqa.selenium.NoSuchElementException: An element could not be located on the page using the given search parameters. (WARNING: The server did not provide any stacktrace information)\nCommand duration or timeout: 0 milliseconds\nFor documentation on this error, please visit: http://seleniumhq.org/exceptions/no_such_element.html\nBuild info: version: '3.5.3', revision: 'a88d25fe6b', time: '2017-08-29T12:42:44.417Z'\nSystem info: host: 'INshridhk.local', ip: 'fe80:0:0:0:43d:f11e:5bfd:1670%en0', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.12.6', java.version: '1.8.0_65'\nDriver info: io.appium.java_client.android.AndroidDriver\nCapabilities [{app=/Users/shridhk/GitHub/Documents/AppiumTestDistribution/AndroidCalculator.apk, noSign=true, automationName=UIAutomator2, javascriptEnabled=true, udid=FA66VBN01980, platformName=ANDROID, deviceName=android, platform=ANDROID, systemPort=63766}]\nSession ID: 7adb6253-28e0-464a-9724-2f894095fcc3\n*** Element info: {Using=accessibility id, value=doubleTap}",
          "methodname": "Testing Skips"
        },
        "totaltime": 30,
        "model": "HTC 10_htc",
        "id": "FA66VBN01980",
        "version": "6.0.1",
        "platform": "ANDROID"
      },
      {
        "testDetails": {
          "classname": "HomePageTest2",
          "endtime": 1508414048,
          "starttime": 1508414017,
          "results": "Fail",
          "logs": {
            "screenShotFailure": "screenshot/android/FA66VBN01980/TestResult/testMethodOne2/2017-10-19T17:24:09_testMethodOne2_failed.jpeg"
          },
          "exceptiontrace": "org.openqa.selenium.NoSuchElementException: An element could not be located on the page using the given search parameters. (WARNING: The server did not provide any stacktrace information)\nCommand duration or timeout: 0 milliseconds\nFor documentation on this error, please visit: http://seleniumhq.org/exceptions/no_such_element.html\nBuild info: version: '3.5.3', revision: 'a88d25fe6b', time: '2017-08-29T12:42:44.417Z'\nSystem info: host: 'INshridhk.local', ip: 'fe80:0:0:0:43d:f11e:5bfd:1670%en0', os.name: 'Mac OS X', os.arch: 'x86_64', os.version: '10.12.6', java.version: '1.8.0_65'\nDriver info: io.appium.java_client.android.AndroidDriver\nCapabilities [{app=/Users/shridhk/GitHub/Documents/AppiumTestDistribution/AndroidCalculator.apk, noSign=true, automationName=UIAutomator2, javascriptEnabled=true, udid=FA66VBN01980, platformName=ANDROID, deviceName=android, platform=ANDROID, systemPort=64559}]\nSession ID: 93be74ed-c32f-4e28-b62a-270017fc09fb\n*** Element info: {Using=accessibility id, value=doubleTap}",
          "methodname": "Testing Skips"
        },
        "totaltime": 30,
        "model": "HTC 10_htc",
        "id": "FA66VBN01980",
        "version": "6.0.1",
        "platform": "ANDROID"
      }
    ],
    "userMetaData": {
      "Appium": "1.6.6.beta4"
    }
  }
}
```