### PR TITLE
Fixing the web driver exception on iOS real device tests

### DIFF
--- a/src/main/java/com/appium/manager/AppiumDriverManager.java
+++ b/src/main/java/com/appium/manager/AppiumDriverManager.java
@@ -3,8 +3,6 @@ package com.appium.manager;
 import com.appium.entities.MobilePlatform;
 import com.appium.ios.IOSDeviceConfiguration;
 import com.appium.utils.DesiredCapabilityBuilder;
-import com.appium.utils.DevicesByHost;
-import com.appium.utils.HostMachineDeviceManager;
 import io.appium.java_client.AppiumDriver;
 import io.appium.java_client.MobileElement;
 import io.appium.java_client.android.AndroidDriver;
@@ -164,7 +162,11 @@ public class AppiumDriverManager {
         if (AppiumDeviceManager.getAppiumDevice().getDevice().getUdid().length()
                 == IOSDeviceConfiguration.IOS_UDID_LENGTH) {
             String hostName = AppiumDeviceManager.getAppiumDevice().getHostName();
-            AppiumManagerFactory.getAppiumManager(hostName).destroyAppiumNode(hostName);
+            try {
+                AppiumManagerFactory.getAppiumManager(hostName).destoryIOSWebKitProxy(hostName);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
         if (AppiumDriverManager.getDriver() != null
                 && AppiumDriverManager.getDriver().getSessionId() != null) {

--- a/src/main/java/com/appium/manager/AppiumDriverManager.java
+++ b/src/main/java/com/appium/manager/AppiumDriverManager.java
@@ -23,6 +23,7 @@ public class AppiumDriverManager {
     private DesiredCapabilityBuilder desiredCapabilityBuilder;
     private ConfigFileManager prop;
     private static final Logger LOGGER = Logger.getLogger(Class.class.getName());
+    private Logger logger;
 
     public AppiumDriverManager() throws Exception {
         iosDeviceConfiguration = new IOSDeviceConfiguration();
@@ -158,15 +159,11 @@ public class AppiumDriverManager {
         }
     }
 
-    public void stopAppiumDriver() throws IOException, InterruptedException {
+    public void stopAppiumDriver() throws Exception {
         if (AppiumDeviceManager.getAppiumDevice().getDevice().getUdid().length()
                 == IOSDeviceConfiguration.IOS_UDID_LENGTH) {
             String hostName = AppiumDeviceManager.getAppiumDevice().getHostName();
-            try {
-                AppiumManagerFactory.getAppiumManager(hostName).destoryIOSWebKitProxy(hostName);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+            AppiumManagerFactory.getAppiumManager(hostName).destoryIOSWebKitProxy(hostName);
         }
         if (AppiumDriverManager.getDriver() != null
                 && AppiumDriverManager.getDriver().getSessionId() != null) {


### PR DESCRIPTION
 Fixing the web driver exception  by stopping the ios webkit debug proxy instead of destroying the appium node